### PR TITLE
Use comma-free syntax for the hsl color notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 ### Fixed
 
+## [2.0.0] - 2023-04-04
+
+### Changed
+
+- [BREAKING] Changed to the newer comma-free color syntax for hsl values (e.g. `hsl(198deg, 28%, 28%)` becomes `hsl(198deg 28% 28%)`). This might be breaking in case you use the colors in combination with alpha (e.g. `hsl(var(--color-mint-hsl), 50%)` should become `hsl(var(--color-mint-hsl) / 50%)`). We also noticed that postcss was having issues with the previous notation and removing the comma before the alpha, causing the color to be invalid. ([@lowiebenoot](https://github.com/lowiebenoot) in [#5](https://github.com/teamleadercrm/ui-colors/pull/5))
+
 ## [1.1.0] - 2023-01-06
 
 ### Added

--- a/scripts/build-css.js
+++ b/scripts/build-css.js
@@ -12,7 +12,7 @@ function getColorCSS(color, tint, hex) {
   --color-${name}-hsl-h: ${Math.round(h)};
   --color-${name}-hsl-s: ${s}%;
   --color-${name}-hsl-l: ${l}%;
-  --color-${name}-hsl: var(--color-${name}-hsl-h), var(--color-${name}-hsl-s), var(--color-${name}-hsl-l);
+  --color-${name}-hsl: var(--color-${name}-hsl-h) var(--color-${name}-hsl-s) var(--color-${name}-hsl-l);
   --color-${name}: hsl(var(--color-${name}-hsl));`;
 }
 


### PR DESCRIPTION
Changed the color syntax to the newer syntax without commas because we're having some issues with postcss removing the comma and causing an invalid color when you do for example `hsl(var(--color-teal-dark-hsl), 50%);`.

It's also the preferred syntax now for newer features: https://twitter.com/mathias/status/1253242715304857601


## [2.0.0] - 2023-04-04

### Changed

- [BREAKING] Changed to the newer comma-free color syntax for hsl values (e.g. `hsl(198deg, 28%, 28%)` becomes `hsl(198deg 28% 28%)`). This might be breaking in case you use the colors in combination with alpha (e.g. `hsl(var(--color-mint-hsl), 50%)` should become `hsl(var(--color-mint-hsl) / 50%)`). We also noticed that postcss was having issues with the previous notation and removing the comma before the alpha, causing the color to be invalid. ([@lowiebenoot](https://github.com/lowiebenoot) in [#5](https://github.com/teamleadercrm/ui-colors/pull/5))
